### PR TITLE
add dateSent to list of date converted strings

### DIFF
--- a/lib/RestClient.js
+++ b/lib/RestClient.js
@@ -88,7 +88,7 @@ function processKeys(source) {
         });
 
         //Look for and convert date strings for specific keys
-        ['startDate', 'endDate', 'dateCreated', 'dateUpdated', 'startTime', 'endTime'].forEach(function(dateKey) {
+        ['startDate', 'endDate', 'dateCreated', 'dateUpdated', 'startTime', 'endTime', 'dateSent'].forEach(function(dateKey) {
             if (source[dateKey]) {
                 source[dateKey] = new Date(source[dateKey]);
             }


### PR DESCRIPTION
Right now the 'dateSent' property isn't getting automatically formatted as a date. This field is returned in the `getSms` response callback.

I'd like to add that this method of converting dates should be reconsidered for something more flexible. I'd propose searching _all_ fields for things that look datey, or convert to a valid date when they're `Date.parse()`'d. This would add a little processing overhead, though.
